### PR TITLE
xdr_codegen: make struct members always named

### DIFF
--- a/xdr_codegen/src/ast.rs
+++ b/xdr_codegen/src/ast.rs
@@ -89,7 +89,7 @@ pub struct XdrEnum {
 pub struct XdrStruct {
     // TODO: store snake_case -> CameCase transformed name...
     pub name: String,
-    pub members: Vec<Declaration>,
+    pub members: Vec<NamedDeclaration>,
 
     /// Structs that have an optional "pointer" to themselves at the end need special handling
     /// during codegen. This field is filled in during Schema::validate().

--- a/xdr_codegen/src/codegen/alloc.rs
+++ b/xdr_codegen/src/codegen/alloc.rs
@@ -122,10 +122,6 @@ impl XdrStruct {
         buf.code_block("pub fn serialize_alloc(&self) -> Vec<u8>", |buf| {
             buf.add_line("let mut buf = Vec::new();");
             for decl in self.members.iter() {
-                let Declaration::Named(decl) = decl else {
-                    buf.add_line("// void");
-                    continue;
-                };
                 buf.add_line(&format!("// {}:", decl.name));
                 decl.serialize_inline(None, Context::NotInUnion, buf, tab);
             }

--- a/xdr_codegen/src/codegen/deserialize.rs
+++ b/xdr_codegen/src/codegen/deserialize.rs
@@ -165,10 +165,6 @@ impl XdrStruct {
             "pub fn deserialize(&mut self, input: &mut &[u8]) -> Result<(), helpers::DeserializeError>",
             |buf| {
                 for decl in self.members.iter() {
-                    let Declaration::Named(decl) = decl else {
-                        buf.add_line("// void");
-                        continue;
-                    };
                     buf.add_line(&format!("// {}:", decl.name));
                     decl.deserialize_inline(None, buf, tab);
                 }

--- a/xdr_codegen/src/codegen/mod.rs
+++ b/xdr_codegen/src/codegen/mod.rs
@@ -641,9 +641,6 @@ impl XdrStruct {
         buf.type_header();
         buf.code_block(&format!("pub struct {}", self.name), |buf| {
             for decl in self.members.iter() {
-                let Declaration::Named(decl) = decl else {
-                    unimplemented!("'void' is not supported as a struct member");
-                };
                 self.member_declaration(decl, buf, tab);
             }
         });
@@ -660,9 +657,6 @@ impl XdrStruct {
             buf.code_block("fn default() -> Self", |buf| {
                 buf.code_block(&self.name, |buf| {
                     for decl in self.members.iter() {
-                        let Declaration::Named(decl) = decl else {
-                            unimplemented!("'void' is not supported as a struct member");
-                        };
                         buf.add_line(&format!("{}: {},", decl.name, decl.default_value(tab)));
                     }
                 });

--- a/xdr_codegen/src/codegen/no_alloc.rs
+++ b/xdr_codegen/src/codegen/no_alloc.rs
@@ -22,10 +22,6 @@ impl XdrStruct {
         buf.code_block("pub fn serialize(&self, buf: &mut [u8]) -> usize", |buf| {
             buf.add_line("let mut offset = 0;");
             for decl in &self.members {
-                let Declaration::Named(decl) = decl else {
-                    buf.add_line("// void");
-                    continue;
-                };
                 buf.add_line(&format!("// {}:", decl.name));
                 decl.serialize_no_alloc_inline(None, buf, tab);
             }

--- a/xdr_codegen/src/parser.rs
+++ b/xdr_codegen/src/parser.rs
@@ -241,7 +241,7 @@ impl<'src> Parser<'src> {
         variants
     }
 
-    fn xdr_struct_body(&mut self) -> Vec<Declaration> {
+    fn xdr_struct_body(&mut self) -> Vec<NamedDeclaration> {
         self.expect(TokenKind::LeftBrace, "struct body must start with '{'");
         let mut members = Vec::new();
         loop {
@@ -249,7 +249,11 @@ impl<'src> Parser<'src> {
                 self.next();
                 break;
             }
-            members.push(self.declaration());
+            let decl = self.declaration();
+            let Declaration::Named(n) = decl else {
+                panic!("Invalid to have void declaration as a struct member.");
+            };
+            members.push(n);
             self.expect(TokenKind::Semicolon, "Expected ';' following declaration");
         }
 

--- a/xdr_codegen/src/validate.rs
+++ b/xdr_codegen/src/validate.rs
@@ -93,31 +93,35 @@ impl XdrStruct {
 ///
 /// This is recursive because a declaration might refer to a typedef, which might in turn refer to
 /// an optional `outer_name`.
-fn is_declaration_option_of_name(outer_name: &str, decl: &Declaration, tab: &SymbolTable) -> bool {
-    match decl {
-        Declaration::Named(n) => match &n.kind {
-            DeclarationKind::Optional(ty) => {
-                let XdrType::Name(member_type_name) = ty else {
-                    return false;
-                };
-                if *member_type_name != outer_name {
-                    return false;
-                }
-                true
+fn is_declaration_option_of_name(
+    outer_name: &str,
+    n: &NamedDeclaration,
+    tab: &SymbolTable,
+) -> bool {
+    match &n.kind {
+        DeclarationKind::Optional(ty) => {
+            let XdrType::Name(member_type_name) = ty else {
+                return false;
+            };
+            if *member_type_name != outer_name {
+                return false;
             }
-            DeclarationKind::Scalar(ty) => {
-                let XdrType::Name(name) = ty else {
-                    return false;
-                };
-                let def = tab.lookup_definition(name).expect("Undefined name");
-                let Definition::TypeDef(ref typedef) = *def else {
-                    return false;
-                };
-                is_declaration_option_of_name(outer_name, &typedef.decl, tab)
-            }
-            DeclarationKind::Array(_) => false,
-        },
-        Declaration::Void => false,
+            true
+        }
+        DeclarationKind::Scalar(ty) => {
+            let XdrType::Name(name) = ty else {
+                return false;
+            };
+            let def = tab.lookup_definition(name).expect("Undefined name");
+            let Definition::TypeDef(ref typedef) = *def else {
+                return false;
+            };
+            let Declaration::Named(ref n) = typedef.decl else {
+                return false;
+            };
+            is_declaration_option_of_name(outer_name, n, tab)
+        }
+        DeclarationKind::Array(_) => false,
     }
 }
 


### PR DESCRIPTION
The members of XdrStruct were defined to be of type Definition. Definition has two variants, named and void.

There is no use case for void struct members. Every place in the code that iterated over struct members was just "unwrapping" and either skipping void members or panicking.

Since the panicking meant that void struct members were effectively illegal, and since there is no use case for them, it is simpler to just make them not representable by making struct members always a NamedDeclaration.