### PR TITLE
Ensure both variants of UnionBoolBody have named true arm and implied false arm

### DIFF
--- a/xdr_codegen/src/ast.rs
+++ b/xdr_codegen/src/ast.rs
@@ -108,11 +108,7 @@ pub enum XdrUnionBody {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct XdrUnionBoolBody {
-    pub true_arm: Declaration,
-    /// False arm and default arm are equivalent for a bool union.
-    /// False arm should always appear but is typically 'void'.
-    // XXX: get rid of false_arm entirely and force this to be basically an Option<>?
-    pub false_arm: Declaration,
+    pub true_arm: NamedDeclaration,
 }
 
 /// An "enum" style union (as opposed to a bool style union) is used for enum-discriminated as well

--- a/xdr_codegen/src/codegen/alloc.rs
+++ b/xdr_codegen/src/codegen/alloc.rs
@@ -102,14 +102,8 @@ impl ValidatedUnionBoolBody {
         buf.code_block("match &self.inner", |buf| {
             buf.code_block("Some(val) => ", |buf| {
                 buf.add_line("let mut buf = 1_u32.to_be_bytes().to_vec();");
-                match &self.true_arm {
-                    Declaration::Void => {
-                        buf.add_line("// void");
-                    }
-                    Declaration::Named(n) => {
-                        n.serialize_inline(Some("val"), Context::InUnion, buf, tab)
-                    }
-                };
+                self.true_arm
+                    .serialize_inline(Some("val"), Context::InUnion, buf, tab);
                 buf.add_line("buf");
             });
             buf.add_line("None => 0_u32.to_be_bytes().to_vec(),");

--- a/xdr_codegen/src/codegen/deserialize.rs
+++ b/xdr_codegen/src/codegen/deserialize.rs
@@ -109,16 +109,14 @@ impl ValidatedUnionBoolBody {
         buf.add_line("helpers::get_u32(&mut discriminant, input)?;");
         buf.block_statement("match discriminant", |buf| {
             buf.add_line("0 => (*self).inner = None,");
-            match &self.true_arm {
-                Declaration::Void => buf.add_line("_ => {}, // void"),
-                Declaration::Named(n) => {
-                    buf.code_block("_ => ", |buf| {
-                        buf.add_line(&format!("let mut val = {};", n.default_value(tab)));
-                        n.deserialize_inline(Some("val"), buf, tab);
-                        buf.add_line("(*self).inner = Some(val)");
-                    });
-                }
-            };
+            buf.code_block("_ => ", |buf| {
+                buf.add_line(&format!(
+                    "let mut val = {};",
+                    self.true_arm.default_value(tab)
+                ));
+                self.true_arm.deserialize_inline(Some("val"), buf, tab);
+                buf.add_line("(*self).inner = Some(val)");
+            });
         });
     }
 }

--- a/xdr_codegen/src/codegen/mod.rs
+++ b/xdr_codegen/src/codegen/mod.rs
@@ -403,18 +403,7 @@ impl ValidatedUnionBoolBody {
     fn definition_bool(&self, name: &str, buf: &mut CodeBuf, tab: &ValidatedSymbolTable) {
         // XXX: A Bool union nearly always has Void for the false arm.
         // Until I see an example where this is not the case, express it as an Option.
-        let Declaration::Void = self.false_arm else {
-            unimplemented!("Bool union with non-Void false arm is not supported");
-        };
-
-        if let Declaration::Void = self.true_arm {
-            unimplemented!("Bool union with Void true arm is not supported");
-        }
-
-        let inner_type = match &self.true_arm {
-            Declaration::Named(n) => n.as_type_name(tab),
-            Declaration::Void => "()".to_string(),
-        };
+        let inner_type = self.true_arm.as_type_name(tab);
 
         buf.code_block(&format!("pub struct {name}"), |buf| {
             buf.add_line(&format!("pub inner: Option<{inner_type}>,"));

--- a/xdr_codegen/src/codegen/no_alloc.rs
+++ b/xdr_codegen/src/codegen/no_alloc.rs
@@ -48,12 +48,8 @@ impl ValidatedUnionBoolBody {
         buf.code_block("match &self.inner", |buf| {
             buf.code_block("Some(val) => ", |buf| {
                 buf.serialize_int(1);
-                match &self.true_arm {
-                    Declaration::Void => {
-                        buf.add_line("// void");
-                    }
-                    Declaration::Named(n) => n.serialize_no_alloc_inline(Some("val"), buf, tab),
-                };
+                self.true_arm
+                    .serialize_no_alloc_inline(Some("val"), buf, tab);
             });
             buf.code_block("None => ", |buf| buf.serialize_int(0));
         });

--- a/xdr_codegen/src/ir.rs
+++ b/xdr_codegen/src/ir.rs
@@ -1,6 +1,4 @@
-use crate::ast::{
-    ConstDefinition, Declaration, DefaultUnionArm, NamedDeclaration, UnionArm, Value, XdrTypeDef,
-};
+use crate::ast::{ConstDefinition, DefaultUnionArm, NamedDeclaration, UnionArm, Value, XdrTypeDef};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DefinitionSize {
@@ -65,11 +63,7 @@ pub enum ValidatedUnionBody {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ValidatedUnionBoolBody {
-    pub true_arm: Declaration,
-    /// False arm and default arm are equivalent for a bool union.
-    /// False arm should always appear but is typically 'void'.
-    // XXX: get rid of false_arm entirely and force this to be basically an Option<>?
-    pub false_arm: Declaration,
+    pub true_arm: NamedDeclaration,
 
     pub size: DefinitionSize,
 }

--- a/xdr_codegen/src/parser.rs
+++ b/xdr_codegen/src/parser.rs
@@ -296,11 +296,14 @@ impl<'src> Parser<'src> {
             }
             TokenKind::Bool => {
                 self.xdr_union_discriminant_remainder();
-                let (true_arm, false_arm) = self.xdr_union_bool_body();
-                XdrUnionBody::Bool(XdrUnionBoolBody {
-                    true_arm,
-                    false_arm,
-                })
+                let (Declaration::Named(true_arm), Declaration::Void) = self.xdr_union_bool_body()
+                else {
+                    panic!(
+                        "xdr_union_bool_body: true arm must be named and false arm must be void!"
+                    );
+                };
+
+                XdrUnionBody::Bool(XdrUnionBoolBody { true_arm })
             }
             // XXX: remove the "Enum" case?
             TokenKind::Enum => {

--- a/xdr_codegen/src/validate.rs
+++ b/xdr_codegen/src/validate.rs
@@ -308,11 +308,7 @@ impl XdrUnionBoolBody {
         _tab: &ValidatedSymbolTable,
         _size_tab: &SizeTab,
     ) -> ValidatedDefinition {
-        let arm_names: Vec<String> = [self.true_arm.name(), self.false_arm.name()]
-            .iter()
-            .filter_map(|val| *val)
-            .map(|val| val.to_string())
-            .collect();
+        let arm_names = vec![self.true_arm.name.clone()];
 
         // bool union body size is never known as there is always a void member and a non void
         // member
@@ -320,7 +316,6 @@ impl XdrUnionBoolBody {
             name: u_name,
             body: ValidatedUnionBody::Bool(ValidatedUnionBoolBody {
                 true_arm: self.true_arm,
-                false_arm: self.false_arm,
                 size: DefinitionSize {
                     known: 0,
                     deps: arm_names.clone(),


### PR DESCRIPTION
This should have been done as a result of #8 where we essentially enforce non-void true arms and void false arms in the parser.