### PR TITLE
tests: disable doctest

### DIFF
--- a/nfs3/Cargo.toml
+++ b/nfs3/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [lib]
 name = "nfs3"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "mountd"

--- a/rpc_protocol/Cargo.toml
+++ b/rpc_protocol/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [lib]
 name = "rpc_protocol"
 path = "src/lib.rs"
+doctest = false
 
 
 [dependencies]

--- a/rpcbind/Cargo.toml
+++ b/rpcbind/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [lib]
 name = "rpcbind"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "rpcinfo"

--- a/xdr_lib/Cargo.toml
+++ b/xdr_lib/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [lib]
 name = "xdr_lib"
 path = "src/lib.rs"
+doctest = false


### PR DESCRIPTION
to reduce noise in the output when running `cargo test`