### PR TITLE
Feature/serialize get width

### DIFF
--- a/tests/no_alloc/tests/arrays.rs
+++ b/tests/no_alloc/tests/arrays.rs
@@ -15,6 +15,8 @@ fn fixed_length_byte_arrays() {
         d: [1u8, 0u8, 3u8, 4u8],
     };
 
+    assert_eq!(before.get_width(), 16);
+
     let mut bytes = vec![1; 16];
 
     assert_eq!(16, before.serialize(&mut bytes));
@@ -22,6 +24,7 @@ fn fixed_length_byte_arrays() {
     let mut after = FixedOpaqueArrays::default();
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 16);
 
     assert_eq!(before, after);
 }
@@ -35,6 +38,7 @@ fn limited_length_byte_arrays() {
         d: vec![5u8, 6u8],
         e: vec![6u8, 7u8, 8u8, 9u8],
     };
+    assert_eq!(before.get_width(), 36);
 
     let mut bytes = vec![1; 36];
 
@@ -43,6 +47,7 @@ fn limited_length_byte_arrays() {
     let mut after = LimitedOpaqueArrays::default();
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 36);
 
     assert_eq!(before, after);
 }
@@ -57,6 +62,7 @@ fn limited_length_array_exceeded() {
         d: vec![],
         e: vec![],
     };
+    assert_eq!(before.get_width(), 40);
 
     let mut bytes = vec![0; 36];
 
@@ -66,6 +72,7 @@ fn limited_length_array_exceeded() {
 #[test]
 fn unlimited_byte_array() {
     let before = UnlimitedOpaqueArray { data: vec![7; 499] };
+    assert_eq!(before.get_width(), 504);
 
     let mut bytes = vec![1u8; 504];
 
@@ -73,6 +80,7 @@ fn unlimited_byte_array() {
 
     let mut after = UnlimitedOpaqueArray::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 504);
 
     assert_eq!(before, after);
 }
@@ -83,12 +91,14 @@ fn strings() {
         str: "hello".into(),
         str_2: "world!!!".into(),
     };
+    assert_eq!(before.get_width(), 24);
 
     let mut bytes = vec![1u8; 24];
     assert_eq!(24, before.serialize(&mut bytes));
 
     let mut after = Strings::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 24);
 
     assert_eq!(before, after);
 }
@@ -100,6 +110,7 @@ fn limited_length_string_exceeded() {
         str: "hello, world!".into(),
         str_2: "".into(),
     };
+    assert_eq!(before.get_width(), 24);
 
     let mut bytes = vec![0; 36];
 
@@ -122,6 +133,7 @@ fn arrays_of_user_defined_type() {
             a: u32::MAX - i as u32,
         });
     }
+    assert_eq!(before.get_width(), 2100);
 
     let mut bytes = [1; 2100];
 
@@ -130,6 +142,7 @@ fn arrays_of_user_defined_type() {
     let mut after = IntArrays::default();
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 2100);
 
     assert_eq!(before, after);
 }
@@ -141,6 +154,7 @@ fn too_long_array_of_user_defined_type() {
     for i in 0..8 {
         before.limited.push(AnInt { a: i });
     }
+    assert_eq!(before.get_width(), 16 + 36 + 4);
 
     let mut bytes = [1; 2100];
 

--- a/tests/no_alloc/tests/basic_structs.rs
+++ b/tests/no_alloc/tests/basic_structs.rs
@@ -15,11 +15,14 @@ fn struct_with_primitive_types() {
         d: (u32::MAX as u64) + 1,
     };
 
+    assert_eq!(before.get_width(), 24);
+
     let mut bytes = vec![0; 24];
 
     assert_eq!(24, before.serialize(&mut bytes));
 
     let mut after = Simple::default();
+    assert_eq!(after.get_width(), 24);
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
 
@@ -35,6 +38,8 @@ fn buf_too_small() {
         c: 0,
         d: (u32::MAX as u64) + 1,
     };
+
+    assert_eq!(before.get_width(), 24);
 
     let mut bytes = vec![0; 23];
 
@@ -59,11 +64,14 @@ fn struct_with_inner_struct() {
         },
     };
 
+    assert_eq!(before.get_width(), 52);
+
     let mut bytes = vec![0; 52];
 
     assert_eq!(52, before.serialize(&mut bytes));
 
     let mut after = Container::default();
+    assert_eq!(after.get_width(), 52);
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
 
@@ -73,12 +81,14 @@ fn struct_with_inner_struct() {
 #[test]
 fn struct_with_typedef() {
     let before = HasTypedef { blah: -12345 };
+    assert_eq!(before.get_width(), 4);
 
     let mut bytes = vec![0; 4];
 
     assert_eq!(4, before.serialize(&mut bytes));
 
     let mut after = HasTypedef::default();
+    assert_eq!(after.get_width(), 4);
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
 

--- a/tests/no_alloc/tests/optionals.rs
+++ b/tests/no_alloc/tests/optionals.rs
@@ -13,21 +13,30 @@ fn recursive_optional() {
         let node = ListNode { data: i };
         before.list.push(node);
     }
+    assert_eq!(before.get_width(), 44);
 
     let mut bytes = vec![1; 44];
     assert_eq!(44, before.serialize(&mut bytes));
+
     let mut after = ListBegin::default();
+
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(44, after.get_width());
+
     assert_eq!(before, after);
 }
 
 #[test]
 fn non_recursive_optional_none() {
     let before = JustAnOption { maybe: None };
+    assert_eq!(before.get_width(), 4);
 
     let mut bytes = vec![1; 4];
     assert_eq!(4, before.serialize(&mut bytes));
+
     let mut after = JustAnOption::default();
+    assert_eq!(after.get_width(), 4);
+
     after.deserialize(&mut bytes.as_slice()).unwrap();
     assert_eq!(before, after);
 }
@@ -40,11 +49,15 @@ fn non_recursive_optional_some() {
             str: "Hello, world!".into(),
         }),
     };
+    assert_eq!(before.get_width(), 28);
 
     let mut bytes = vec![1; 28];
     assert_eq!(28, before.serialize(&mut bytes));
+
     let mut after = JustAnOption::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 28);
+
     assert_eq!(before, after);
 }
 
@@ -64,10 +77,14 @@ fn mount_proto_export_list() {
         }
         before.inner.push(export);
     }
+    assert_eq!(before.get_width(), 504);
 
     let mut bytes = vec![1; 1024];
     assert_eq!(504, before.serialize(&mut bytes));
+
     let mut after = exports::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 504);
+
     assert_eq!(before, after);
 }

--- a/tests/no_alloc/tests/unions.rs
+++ b/tests/no_alloc/tests/unions.rs
@@ -8,6 +8,7 @@ use unions::*;
 fn bool_union() {
     // True case:
     let before = MyOption { inner: Some(7) };
+    assert_eq!(before.get_width(), 8);
 
     let mut bytes = vec![1; 8];
     assert_eq!(8, before.serialize(&mut bytes));
@@ -15,14 +16,17 @@ fn bool_union() {
     let mut after = MyOption::default();
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 8);
     assert_eq!(before, after);
 
     // False case:
     let before = MyOption { inner: None };
 
+    assert_eq!(4, before.get_width());
     assert_eq!(4, before.serialize(&mut bytes));
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(4, after.get_width());
     assert_eq!(before, after);
 }
 
@@ -46,22 +50,28 @@ fn invalid_enum_variant() {
 #[test]
 fn enum_union_no_default() {
     let before = Stuff::one(99);
+    assert_eq!(before.get_width(), 8);
     let mut bytes = [1; 100];
     assert_eq!(8, before.serialize(&mut bytes));
     let mut after = Stuff::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 8);
     assert_eq!(before, after);
 
     let before = Stuff::two(MyOption {
         inner: Some(i32::MAX),
     });
+    assert_eq!(before.get_width(), 12);
     assert_eq!(12, before.serialize(&mut bytes));
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 12);
     assert_eq!(before, after);
 
     let before = Stuff::three;
+    assert_eq!(before.get_width(), 4);
     assert_eq!(4, before.serialize(&mut bytes));
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 4);
     assert_eq!(before, after);
 }
 
@@ -69,9 +79,11 @@ fn enum_union_no_default() {
 fn enum_union_default_void() {
     let before = Things::Default;
     let mut bytes = [1; 4];
+    assert_eq!(before.get_width(), 4);
     assert_eq!(4, before.serialize(&mut bytes));
     let mut after = Things::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 4);
     assert_eq!(before, after);
 }
 
@@ -79,9 +91,11 @@ fn enum_union_default_void() {
 fn enum_union_default_non_void() {
     let before = MoreThings::Default(7);
     let mut bytes = [1; 8];
+    assert_eq!(before.get_width(), 8);
     assert_eq!(8, before.serialize(&mut bytes));
     let mut after = MoreThings::default();
     after.deserialize(&mut bytes.as_slice()).unwrap();
+    assert_eq!(after.get_width(), 8);
     assert_eq!(before, after);
 }
 

--- a/xdr_codegen/src/codegen/deserialize.rs
+++ b/xdr_codegen/src/codegen/deserialize.rs
@@ -164,10 +164,18 @@ impl ValidatedUnionEnumBody {
 
 impl ValidatedStruct {
     pub fn offset_to_string(off: &DeclarationOfset) -> String {
+        Self::offset_to_string_with_unwrapper(off, "?")
+    }
+
+    pub fn offset_to_string_infallible(off: &DeclarationOfset) -> String {
+        Self::offset_to_string_with_unwrapper(off, ".unwrap()")
+    }
+
+    pub fn offset_to_string_with_unwrapper(off: &DeclarationOfset, unwrapper: &str) -> String {
         let code = off
             .deps
             .iter()
-            .map(|v| format!("self.get_{}_width()?", v))
+            .map(|v| format!("self.get_{}_width(){}", v, unwrapper))
             .chain(
                 vec![format!("{}", off.known)]
                     .into_iter()
@@ -188,26 +196,6 @@ impl ValidatedStruct {
             .deps
             .iter()
             .map(|v| format!("{}_width", v))
-            .chain(
-                vec![format!("{}", off.known)]
-                    .into_iter()
-                    .filter(|v| v != "0"),
-            )
-            .collect::<Vec<String>>()
-            .join(" + ");
-
-        if code.is_empty() {
-            "0".to_string()
-        } else {
-            code.clone()
-        }
-    }
-
-    pub fn offset_to_string_infallible(off: &DeclarationOfset) -> String {
-        let code = off
-            .deps
-            .iter()
-            .map(|v| format!("self.get_{}_width().unwrap()", v))
             .chain(
                 vec![format!("{}", off.known)]
                     .into_iter()

--- a/xdr_codegen/src/codegen/mod.rs
+++ b/xdr_codegen/src/codegen/mod.rs
@@ -367,6 +367,79 @@ impl NamedDeclaration {
             _ => false,
         }
     }
+
+    fn is_self_referential(&self, tab: &ValidatedSymbolTable) -> bool {
+        match &self.kind {
+            DeclarationKind::Scalar(xdr_type) | DeclarationKind::Optional(xdr_type) => {
+                xdr_type.self_referential_optional(tab)
+            }
+            DeclarationKind::Array(_) => false,
+        }
+    }
+
+    fn get_width(&self, buf: &mut CodeBuf, name: &str, tab: &ValidatedSymbolTable) {
+        match &self.kind {
+            DeclarationKind::Scalar(t) => t.get_width(buf, name, tab),
+            DeclarationKind::Array(array) => match &array.kind {
+                ArrayKind::Byte | ArrayKind::Ascii => {
+                    let count_addition = if let ArraySize::Fixed(_) = &array.size {
+                        ""
+                    } else {
+                        "4usize + "
+                    };
+                    buf.add_line(&format!(
+                        "{}xdr_lib::padded_4byte({}.len())",
+                        count_addition, name
+                    ))
+                }
+                ArrayKind::UserType(xdr_type) => {
+                    let elem_size = xdr_type.size(tab);
+                    let count_addition = if let ArraySize::Fixed(_) = &array.size {
+                        ""
+                    } else {
+                        "4usize + "
+                    };
+                    if let Some(elem_size) = elem_size {
+                        buf.add_line(&format!(
+                            "{}xdr_lib::padded_4byte({}.len() * {})",
+                            count_addition, name, elem_size
+                        ));
+                    } else {
+                        buf.block_with_trailer(
+                            &format!(
+                                "{count_addition}xdr_lib::padded_4byte({}.iter().map(|_v|",
+                                name
+                            ),
+                            ").sum())",
+                            |buf| {
+                                xdr_type.get_width(buf, "_v", tab);
+                            },
+                        );
+                    }
+                }
+            },
+            DeclarationKind::Optional(xdr_type) => {
+                if self.is_self_referential(tab) {
+                    buf.block_with_trailer(
+                        &format!("4usize + xdr_lib::padded_4byte({}.iter().map(|_v|", name),
+                        ").sum())",
+                        |buf| {
+                            buf.code_block("4usize +", |buf| {
+                                xdr_type.get_width(buf, "_v", tab);
+                            });
+                        },
+                    );
+                } else {
+                    buf.code_block(&format!("4usize + match &{}", name), |buf| {
+                        buf.add_line("None => 0,");
+                        buf.code_block("Some(_val) =>", |buf| {
+                            xdr_type.get_width(buf, "_val", tab);
+                        });
+                    })
+                }
+            }
+        }
+    }
 }
 
 impl ValidatedUnion {
@@ -383,6 +456,8 @@ impl ValidatedUnion {
             if !params.zcopy {
                 self.deserialize_definition(buf, tab);
             }
+            buf.add_line("");
+            self.width_getter(buf, tab);
         });
 
         if params.zcopy {
@@ -404,6 +479,44 @@ impl ValidatedUnion {
                 ValidatedUnionBody::Bool(b) => b.default_bool(buf),
                 ValidatedUnionBody::Enum(e) => e.default_enum(buf, tab),
             })
+        });
+    }
+    fn width_getter(&self, buf: &mut CodeBuf, tab: &ValidatedSymbolTable) {
+        buf.code_block("pub fn get_width(&self) -> usize", |buf| match &self.body {
+            ValidatedUnionBody::Bool(validated_union_bool_body) => {
+                buf.code_block("4usize + match &self.inner", |buf| {
+                    buf.add_line("None => 0,");
+                    buf.code_block("Some(_val) =>", |buf| {
+                        validated_union_bool_body
+                            .true_arm
+                            .get_width(buf, "_val", tab);
+                    });
+                })
+            }
+            ValidatedUnionBody::Enum(e) => {
+                buf.code_block("4usize + match &self", |buf| {
+                    for arm in e.arms.iter() {
+                        let name = ValidatedUnionEnumBody::arm_name(&arm.0);
+                        match &arm.1 {
+                            Declaration::Void => buf.add_line(&format!("Self::{name} => 0,")),
+                            Declaration::Named(n) => {
+                                buf.code_block(&format!("Self::{name}(_val) =>"), |buf| {
+                                    n.get_width(buf, "_val", tab);
+                                });
+                            }
+                        };
+                    }
+                    match &e.default_arm {
+                        Some(Declaration::Void) => buf.add_line("Self::Default => 0,"),
+                        Some(Declaration::Named(n)) => {
+                            buf.code_block("Self::Default(_val) =>", |buf| {
+                                n.get_width(buf, "_val", tab);
+                            });
+                        }
+                        None => {}
+                    }
+                });
+            }
         });
     }
 }
@@ -676,6 +789,8 @@ impl ValidatedStruct {
             if !params.zcopy {
                 self.deserialize_definition(buf, tab);
             }
+            buf.add_line("");
+            self.width_getters(buf, tab);
         });
         if params.zcopy {
             buf.code_block(&format!("impl<'a> {}Reader<'a>", self.name), |buf| {
@@ -690,6 +805,39 @@ impl ValidatedStruct {
             });
         }
         buf.add_line("");
+    }
+
+    fn width_getters(&self, buf: &mut CodeBuf, tab: &ValidatedSymbolTable) {
+        let varlen_members = self.get_variable_width_members(tab);
+
+        for name in varlen_members {
+            let (member, _) = self.members.iter().find(|val| val.0.name == *name).unwrap();
+
+            buf.code_block(&format!("fn get_{}_width(&self) -> usize", name), |buf| {
+                member.get_width(buf, &format!("self.{}", name), tab)
+            });
+        }
+
+        buf.code_block("pub fn get_width(&self) -> usize", |buf| {
+            if let Some((last, last_off)) = self.members.last() {
+                let last_size = last.size(tab);
+                let mut overall_definition_size = DefinitionSize {
+                    known: last_off.known + last_size.unwrap_or(0),
+                    deps: last_off.deps.clone(),
+                };
+
+                if last_size.is_none() {
+                    overall_definition_size.deps.push(last.name.clone());
+                }
+
+                buf.add_line(&Self::offset_to_string_with_unwrapper(
+                    &overall_definition_size,
+                    "",
+                ));
+            } else {
+                buf.add_line("0");
+            }
+        });
     }
 
     fn definition(&self, buf: &mut CodeBuf, tab: &ValidatedSymbolTable) {
@@ -932,6 +1080,33 @@ impl XdrType {
         match self {
             XdrType::Name(n) => tab.lookup_definition(n).is_reader(tab),
             _ => false,
+        }
+    }
+
+    fn get_width(&self, buf: &mut CodeBuf, name: &str, tab: &ValidatedSymbolTable) {
+        match self {
+            XdrType::Name(n) => {
+                let found = tab.lookup_definition(n);
+
+                let defsize = found.size(tab);
+
+                if defsize.is_determinate() {
+                    buf.add_line(&format!("{}", defsize.known));
+                } else {
+                    match found {
+                        ValidatedDefinition::Const(_) => unreachable!(),
+                        ValidatedDefinition::TypeDef(td) => td.decl.get_width(buf, name, tab),
+                        ValidatedDefinition::Struct(_) => {
+                            buf.add_line(&format!("{name}.get_width()"));
+                        }
+                        ValidatedDefinition::Enum(_) => buf.add_line("4"),
+                        ValidatedDefinition::Union(_) => {
+                            buf.add_line(&format!("{name}.get_width()"));
+                        }
+                    }
+                }
+            }
+            _ => buf.add_line(&format!("{}", self.size(tab).unwrap())),
         }
     }
 }

--- a/xdr_lib/src/lib.rs
+++ b/xdr_lib/src/lib.rs
@@ -70,8 +70,12 @@ pub fn serialize_bool(src: &bool) -> [u8; 4] {
     }
 }
 
+pub fn padded_4byte(len: usize) -> usize {
+    (len + 3) & !(0b11usize)
+}
+
 pub fn encode_padding(offset: usize, buf: &mut [u8]) -> usize {
-    let padded_offset: usize = (offset + 3) & !(0b11usize);
+    let padded_offset: usize = padded_4byte(offset);
     buf[offset..padded_offset].fill(0u8);
     padded_offset
 }


### PR DESCRIPTION
This adds generation of `get_width(&self) -> usize` functions to structures passed into serialization routines. With this addition, one can precompute the encoded width of xdr structures and thus can guarantee the success of serialization routines as well as minimize allocations.