### PR TITLE
Feature/codegen trailing eof

### DIFF
--- a/tests/input/optional.x
+++ b/tests/input/optional.x
@@ -5,6 +5,7 @@ struct ListNode {
 
 struct ListBegin {
     ListNode *list;
+    bool eof;
 };
 
 struct NonRecursive {
@@ -33,14 +34,15 @@ struct groupnode {
    groups   gr_next;
 };
 
-struct exports {
-   exportnode *inner;
-};
-
 struct exportnode {
    dirpath  ex_dir;
    groups   ex_groups;
    exportnode *ex_next;
+};
+
+
+struct exports {
+   exportnode *inner;
 };
 
 enum MyEnum {

--- a/tests/no_alloc/tests/optionals.rs
+++ b/tests/no_alloc/tests/optionals.rs
@@ -13,15 +13,15 @@ fn recursive_optional() {
         let node = ListNode { data: i };
         before.list.push(node);
     }
-    assert_eq!(before.get_width(), 44);
+    assert_eq!(before.get_width(), 48);
 
-    let mut bytes = vec![1; 44];
-    assert_eq!(44, before.serialize(&mut bytes));
+    let mut bytes = vec![1; 48];
+    assert_eq!(48, before.serialize(&mut bytes));
 
     let mut after = ListBegin::default();
 
     after.deserialize(&mut bytes.as_slice()).unwrap();
-    assert_eq!(44, after.get_width());
+    assert_eq!(48, after.get_width());
 
     assert_eq!(before, after);
 }

--- a/tests/zcopy/tests/optional.rs
+++ b/tests/zcopy/tests/optional.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: BSD-3-Clauss
 // Copyright 2025. Triad National Security, LLC.
 
 use std::os::unix::ffi::OsStrExt;
@@ -58,7 +58,8 @@ fn test_optionals_recursive() {
         integers.push(i);
     }
 
-    for i in 0i32..110 {
+    // the first entry should read as an eof() == true
+    for i in 1i32..110 {
         data.extend([0x0, 0x0, 0x0, 0x0]);
         data.extend(i.to_be_bytes());
     }
@@ -67,7 +68,8 @@ fn test_optionals_recursive() {
     let actual_ints: Vec<i32> = reader.get_list().map(|v| v.unwrap().get_data()).collect();
 
     assert_eq!(integers, actual_ints);
-    assert_eq!(reader.get_width(), Ok(8 * 100 + 4));
+    assert_eq!(reader.get_width(), Ok(8 * 100 + 8));
+    assert!(reader.get_eof());
 }
 
 #[test]
@@ -92,6 +94,7 @@ fn test_optionals_recursive_missing_last_discriminant() {
         data.extend(i.to_be_bytes());
         integers.push(Ok(i));
     }
+    data.extend([0x0, 0x0, 0x0, 0x0]);
     integers.push(Err(DeserializeError));
 
     let reader = ListBeginReader::new(&data.as_slice()[..data.len()]).unwrap();
@@ -151,7 +154,7 @@ fn test_optionals_recursive_varlen_interiors() {
     let reader = exportsReader::new(data.as_slice()).unwrap();
     for (i, en) in reader.get_inner().enumerate() {
         assert_eq!(
-            export_groups.get(i).unwrap().dirpath.as_str().as_bytes(),
+            export_groups.get(i).unwrap().dirpath.as_bytes(),
             en.as_ref().unwrap().get_ex_dir().as_bytes()
         );
 
@@ -164,7 +167,8 @@ fn test_optionals_recursive_varlen_interiors() {
                 .unwrap()
                 .name
                 .as_bytes();
-            let second_string = gn.unwrap().get_gr_name().as_bytes();
+            let gn = gn.unwrap();
+            let second_string = gn.get_gr_name().as_bytes();
             assert_eq!(first_string, second_string);
         }
     }

--- a/xdr_codegen/src/codegen/mod.rs
+++ b/xdr_codegen/src/codegen/mod.rs
@@ -1058,7 +1058,7 @@ impl XdrType {
     ///
     /// Such types are represented in Rust as Vectors, rather than linked lists.
     /// Non-self-referential optional types are represented as Rust Options.
-    fn self_referential_optional(&self, tab: &ValidatedSymbolTable) -> bool {
+    pub(crate) fn self_referential_optional(&self, tab: &ValidatedSymbolTable) -> bool {
         let XdrType::Name(n) = self else {
             return false;
         };

--- a/xdr_codegen/src/codegen/zcopy_deser.rs
+++ b/xdr_codegen/src/codegen/zcopy_deser.rs
@@ -46,16 +46,24 @@ impl NamedDeclaration {
 
         fallible_parent: bool,
         member_name: Option<String>,
+        eof_tail: bool,
     ) {
         match &self.kind {
             DeclarationKind::Scalar(ty) => {
-                ty.get_size_inline_zcopy(buf, tab, fallible_parent, member_name);
+                ty.get_size_inline_zcopy(buf, tab, fallible_parent, member_name, eof_tail);
             }
             DeclarationKind::Array(a) => {
                 a.get_size_inline_zcopy(buf, tab);
             }
             DeclarationKind::Optional(ty) => {
-                ty.get_optional_size_inline_zcopy(buf, tab, fallible_parent, member_name);
+                ty.get_optional_size_inline_zcopy(
+                    buf,
+                    tab,
+                    fallible_parent,
+                    member_name.clone(),
+                    member_name.map(|v| v.to_string()).as_deref(),
+                    eof_tail,
+                );
             }
         }
     }
@@ -65,16 +73,30 @@ impl NamedDeclaration {
         buf: &mut CodeBuf,
         tab: &ValidatedSymbolTable,
         fallible_parent: bool,
+        member_name: Option<String>,
+        eof_tail: bool,
     ) {
         match &self.kind {
             DeclarationKind::Scalar(ty) => {
-                ty.deserialize_inline_zcopy(buf, tab, fallible_parent);
+                ty.deserialize_inline_zcopy(
+                    buf,
+                    tab,
+                    fallible_parent,
+                    Some(self.name.clone()),
+                    eof_tail,
+                );
             }
             DeclarationKind::Array(a) => {
                 a.deserialize_inline_zcopy(buf, tab, fallible_parent);
             }
             DeclarationKind::Optional(o) => {
-                o.deserialize_optional_inline_zcopy(buf, tab, fallible_parent);
+                o.deserialize_optional_inline_zcopy(
+                    buf,
+                    tab,
+                    fallible_parent,
+                    member_name.map(|v| v.to_string()).as_deref(),
+                    eof_tail,
+                );
             }
         }
     }
@@ -126,13 +148,14 @@ impl XdrType {
 
         fallible_parent: bool,
         member_name: Option<String>,
+        eof_tail: bool,
     ) {
         // Handle typedefs specially by finding their underlying type:
         if let XdrType::Name(name) = self {
             let definition = tab.lookup_definition(name);
             if let ValidatedDefinition::TypeDef(ref tdef) = *definition {
                 tdef.decl
-                    .get_size_inline_zcopy(buf, tab, fallible_parent, member_name);
+                    .get_size_inline_zcopy(buf, tab, fallible_parent, member_name, eof_tail);
                 return;
             };
         };
@@ -172,13 +195,15 @@ impl XdrType {
         tab: &ValidatedSymbolTable,
         fallible_parent: bool,
         reader_name: Option<String>,
+        cache_name: Option<&str>,
+        eof_tail: bool,
     ) {
         // Handle typedefs specially by finding their underlying type:
         if let XdrType::Name(name) = self {
             let definition = tab.lookup_definition(name);
             if let ValidatedDefinition::TypeDef(ref tdef) = *definition {
                 tdef.decl
-                    .get_size_inline_zcopy(buf, tab, fallible_parent, reader_name);
+                    .get_size_inline_zcopy(buf, tab, fallible_parent, reader_name, eof_tail);
                 return;
             };
         };
@@ -189,11 +214,17 @@ impl XdrType {
             buf.code_block("_ =>", |buf| {
                 if self.self_referential_optional(tab) {
                     buf.add_line(&format!(
-                        "let mut it = xdr_lib::LinkedListIter::<'a, {}>::new(_input, {});",
+                        "let mut it = xdr_lib::LinkedListIter::<'a, {}>::new(_input, {}, {}, {});",
                         self.as_zcopy_deser_type_name(tab),
                         self.size(tab)
                             .map(|v| format!("Some({})", v))
-                            .unwrap_or("None".to_string())
+                            .unwrap_or("None".to_string()),
+                        if let Some(cache_name) = cache_name {
+                            format!("Some(&self.{}_width)", cache_name)
+                        } else {
+                            "None".to_string()
+                        },
+                        eof_tail,
                     ));
 
                     buf.add_line("it.by_ref().for_each(drop);");
@@ -204,7 +235,13 @@ impl XdrType {
                 } else {
                     buf.add_line("let off = off + 4;");
                     buf.add_line("let _input = &self.buf[off..];");
-                    self.get_size_inline_zcopy(buf, tab, fallible_parent, reader_name.clone());
+                    self.get_size_inline_zcopy(
+                        buf,
+                        tab,
+                        fallible_parent,
+                        reader_name.clone(),
+                        eof_tail,
+                    );
                     buf.add_line("\t.map(|val| val + 4usize)");
                 }
             });
@@ -216,13 +253,20 @@ impl XdrType {
         buf: &mut CodeBuf,
         tab: &ValidatedSymbolTable,
         fallible_parent: bool,
+        member_name: Option<String>,
+        eof_tail: bool,
     ) {
         // Handle typedefs specially by finding their underlying type:
         if let XdrType::Name(name) = self {
             let definition = tab.lookup_definition(name);
             if let ValidatedDefinition::TypeDef(ref tdef) = *definition {
-                tdef.decl
-                    .deserialize_inline_zcopy(buf, tab, fallible_parent);
+                tdef.decl.deserialize_inline_zcopy(
+                    buf,
+                    tab,
+                    fallible_parent,
+                    member_name,
+                    eof_tail,
+                );
                 return;
             };
         };
@@ -243,14 +287,22 @@ impl XdrType {
         buf: &mut CodeBuf,
         tab: &ValidatedSymbolTable,
         fallible_parent: bool,
+        cache_name: Option<&str>,
+        eof_tail: bool,
     ) {
         if self.self_referential_optional(tab) {
             buf.add_line(&format!(
-                "xdr_lib::LinkedListIter::<'a, {}>::new(_input, {})",
+                "xdr_lib::LinkedListIter::<'a, {}>::new(_input, {}, {}, {})",
                 self.as_zcopy_deser_type_name(tab),
                 self.size(tab)
                     .map(|v| format!("Some({})", v))
-                    .unwrap_or("None".to_string())
+                    .unwrap_or("None".to_string()),
+                if let Some(cache_name) = cache_name {
+                    format!("Some(&self.{}_width)", cache_name)
+                } else {
+                    "None".to_string()
+                },
+                eof_tail
             ));
         } else {
             buf.add_line("let has_val = xdr_lib::get_i32_infallible(_input);");
@@ -261,7 +313,13 @@ impl XdrType {
                         buf.add_line("#[allow(unused_variables)]");
                         buf.add_line("let off = off + 4;");
                         buf.add_line("let _input = &_input[4..];");
-                        self.deserialize_inline_zcopy(buf, tab, fallible_parent);
+                        self.deserialize_inline_zcopy(
+                            buf,
+                            tab,
+                            fallible_parent,
+                            cache_name.map(|v| v.to_string()),
+                            eof_tail,
+                        );
                     });
                     buf.add_line("Some(val)");
                     // buf.add_line("val.map(|v| Some(v))");
@@ -294,15 +352,18 @@ impl XdrType {
 
 impl ValidatedStruct {
     fn definition_zcopy(&self, buf: &mut CodeBuf, tab: &ValidatedSymbolTable) {
-        // let deps = self.get_variable_width_last_deps();
-        let (deps, self_ref_last) = if let Some(last) = self.members.last() {
-            if self.member_is_self_referential(&last.0, tab) {
-                (self.get_variable_width_last_deps(), Some(&last.0))
-            } else {
-                (self.get_variable_width_members(tab), None)
-            }
+        let self_ref_last = if self.contains_self_ref_opt && !self.eof_tail {
+            self.members.last()
+        } else if self.contains_self_ref_opt && self.eof_tail {
+            self.members.get(self.members.len() - 2)
         } else {
-            (self.get_variable_width_last_deps(), None)
+            None
+        };
+
+        let (deps, self_ref_last) = if let Some(last) = self_ref_last {
+            (self.get_variable_width_last_deps(), Some(&last.0))
+        } else {
+            (self.get_variable_width_members(tab), None)
         };
 
         buf.add_line("#[derive(Debug, PartialEq, Clone)]");
@@ -315,7 +376,9 @@ impl ValidatedStruct {
 
                     buf.add_line(&format!("{}: {},", dep, typename));
                 } else {
-                    buf.add_line(&format!("{}_width: usize,", dep));
+                    if !self.member_is_self_referential(member, tab) {
+                        buf.add_line(&format!("{}_width: usize,", dep));
+                    }
                 }
             }
 
@@ -365,7 +428,7 @@ impl ValidatedStruct {
                                             DeclarationKind::Scalar(xdr_type) => match xdr_type {
                                                 XdrType::Name(_) => {
                                                     xdr_type.get_size_inline_zcopy(
-                                                        buf, tab, true, None,
+                                                        buf, tab, true, None, self.eof_tail,
                                                     );
                                                 }
                                                 _ => unreachable!("we should only have indeterminate named types here"),
@@ -375,12 +438,14 @@ impl ValidatedStruct {
                                                 array.get_size_inline_zcopy(buf, tab);
                                             }
                                             DeclarationKind::Optional(xdr_type) => {
-                                xdr_type.get_optional_size_inline_zcopy(
-                                    buf,
-                                    tab,
-                                    true,
-                                    None
-                                );
+                                                xdr_type.get_optional_size_inline_zcopy(
+                                                    buf,
+                                                    tab,
+                                                    true,
+                                                    None,
+                                                    None,
+                                                    self.eof_tail,
+                                                );
                                             }
                                         };
                                     },
@@ -440,8 +505,18 @@ impl ValidatedStruct {
         tab: &ValidatedSymbolTable,
     ) {
         buf.code_block("fn validate(self) -> xdr_lib::Result<Self>", |buf| {
-            if let Some((last, last_off)) = self.members.last() {
-                let last_size = if self.member_is_self_referential(last, tab) {
+            let mut self_ref_last = false;
+            let last = if self.contains_self_ref_opt && !self.eof_tail {
+                self_ref_last = true;
+                self.members.last()
+            } else if self.contains_self_ref_opt && self.eof_tail {
+                self_ref_last = true;
+                self.members.get(self.members.len() - 2)
+            } else {
+                self.members.last()
+            };
+            if let Some((last, last_off)) = last {
+                let last_size = if self_ref_last {
                     // We skip last members who evaluate to iterators, which could be a
                     // large performance sink
                     Some(0)
@@ -491,7 +566,10 @@ impl ValidatedStruct {
 
         for dep in deps.iter() {
             buf.code_block(
-                &format!("pub fn get_{}_width(&self) -> xdr_lib::Result<usize>", dep),
+                &format!(
+                    "pub fn get_{}_width(&'a self) -> xdr_lib::Result<usize>",
+                    dep
+                ),
                 |buf| {
                     let (member, member_off) = self
                         .members
@@ -508,7 +586,14 @@ impl ValidatedStruct {
                                     Self::offset_to_string(member_off)
                                 ));
                                 buf.add_line("let _input = &self.buf[off..];");
-                                xdr_type.get_optional_size_inline_zcopy(buf, tab, true, None);
+                                xdr_type.get_optional_size_inline_zcopy(
+                                    buf,
+                                    tab,
+                                    true,
+                                    None,
+                                    Some(&member.name),
+                                    self.eof_tail,
+                                );
                             }
                             _ => unreachable!(),
                         };
@@ -526,7 +611,7 @@ impl ValidatedStruct {
         for (member, member_off) in self.members.iter() {
             buf.code_block(
                 &format!(
-                    "pub fn get_{}(&self) -> {}",
+                    "pub fn get_{}(&'a self) -> {}",
                     member.name,
                     member.as_zcopy_dser_type_name(tab)
                 ),
@@ -548,7 +633,13 @@ impl ValidatedStruct {
                     buf.add_line("let _input = &self.buf[off..];");
 
                     // Validation can be here
-                    member.deserialize_inline_zcopy(buf, tab, false);
+                    member.deserialize_inline_zcopy(
+                        buf,
+                        tab,
+                        false,
+                        Some(member.name.clone()),
+                        self.eof_tail,
+                    );
                 },
             );
         }
@@ -780,7 +871,9 @@ impl ValidatedUnionBoolBody {
                         ));
                     }
 
-                    self.true_arm.deserialize_inline_zcopy(buf, tab, true)
+                    // TODO: suport recursive optionals in unions if the need arises
+                    self.true_arm
+                        .deserialize_inline_zcopy(buf, tab, true, None, false)
                 });
                 buf.add_line("Some(val)");
             });
@@ -807,7 +900,8 @@ impl ValidatedUnionBoolBody {
                 } else if self.true_arm.is_varlen_reader(tab) {
                     buf.add_line("_inner.get_width()");
                 } else {
-                    self.true_arm.get_size_inline_zcopy(buf, tab, true, None);
+                    self.true_arm
+                        .get_size_inline_zcopy(buf, tab, true, None, false);
                 }
             });
         });
@@ -905,7 +999,8 @@ impl ValidatedUnionEnumBody {
                             // buf.add_line(&format!("let mut inner = {};", n.default_value(tab)));
                             // n.deserialize_inline(Some("inner"), buf, tab);
                             buf.block_with_trailer("let inner =", ";", |buf| {
-                                n.deserialize_inline_zcopy(buf, tab, true);
+                                // TODO: suport recursive optionals in unions if the need arises
+                                n.deserialize_inline_zcopy(buf, tab, true, None, false);
                             });
 
                             buf.add_line(&format!("{u_name}::{arm_name}(inner)"));
@@ -933,7 +1028,8 @@ impl ValidatedUnionEnumBody {
                             }
 
                             buf.block_statement("let inner =", |buf| {
-                                n.deserialize_inline_zcopy(buf, tab, true);
+                                // TODO: suport recursive optionals in unions if the need arises
+                                n.deserialize_inline_zcopy(buf, tab, true, None, false);
                             });
                             buf.add_line(&format!("{u_name}::Default(inner)"));
                         });

--- a/xdr_codegen/src/ir.rs
+++ b/xdr_codegen/src/ir.rs
@@ -44,6 +44,8 @@ pub struct ValidatedStruct {
     /// Structs that have an optional "pointer" to themselves at the end need special handling
     /// during codegen. This field is filled in during Schema::validate().
     pub self_referential_optional: bool,
+    pub contains_self_ref_opt: bool,
+    pub eof_tail: bool,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/xdr_codegen/src/validate.rs
+++ b/xdr_codegen/src/validate.rs
@@ -304,9 +304,7 @@ impl XdrUnionBoolBody {
 }
 
 impl XdrUnionEnumBody {
-    fn validate(self, u_name: String, tab: &ValidatedSymbolTable) -> ValidatedDefinition {
-        let mut arms_iter = self.arms.iter();
-
+    fn validate(mut self, u_name: String, tab: &ValidatedSymbolTable) -> ValidatedDefinition {
         let Some(discriminant_name) = &self.discriminant else {
             todo!("we do not currently support void discriminant unions")
         };
@@ -350,15 +348,13 @@ impl XdrUnionEnumBody {
             }
         }
 
-        // if all the enum cases are covered by the match arms, we can elide the
-        // default case
-        let default_arm = if !left.is_empty() {
-            self.default_arm.as_ref()
-        } else {
-            None
-        };
+        if let Some(default_arm) = self.default_arm.as_ref() {
+            self.arms
+                .extend(left.drain().map(|s| (Value::Name(s), default_arm.clone())));
+        }
 
-        let size = if let Some(default_arm) = default_arm {
+        let mut arms_iter = self.arms.iter();
+        let size = if let Some(default_arm) = self.default_arm.as_ref() {
             let default_size = default_arm.size(tab);
             if default_size.is_none() || arms_iter.all(|(_, d)| d.size(tab) == default_size) {
                 default_size

--- a/xdr_codegen/src/validate.rs
+++ b/xdr_codegen/src/validate.rs
@@ -245,12 +245,62 @@ impl XdrStruct {
             })
             .collect();
 
+        let mut eof_tail = false;
+        let mut has_self_ref = false;
+        // If there is to be a member after a LinkedList type, it must be `bool eof;`
+        let is_eof_bool = members.last().is_some_and(|v| match v.0.kind {
+            DeclarationKind::Scalar(XdrType::Bool) => v.0.name == "eof",
+            _ => false,
+        });
+
+        for (i, (member, _)) in members.iter().enumerate() {
+            // println!(
+            //     "// {}.{} has_self_ref: {}",
+            //     self.name, member.name, has_self_ref
+            // );
+            // println!(
+            //     "// {}.{} is eof bool: {}",
+            //     self.name, member.name, is_eof_bool
+            // );
+            let is_last = (i + 1 == members.len()) || (i + 2 == members.len() && is_eof_bool);
+            // println!("// {} + {} == {}", i, 2, members.len());
+            // println!("// {}.{} is last bool: {}", self.name, member.name, is_last);
+
+            if self.member_is_self_referential(member, tab) {
+                println!("// self ref");
+                println!();
+                if !is_last {
+                    return Err(XdrError::UnsupportedOptional(self.name));
+                }
+
+                has_self_ref = true;
+            }
+
+            if is_last {
+                eof_tail = is_eof_bool;
+            }
+        }
+
         Ok(ValidatedStruct {
             name: self.name,
             members,
             size: s,
             self_referential_optional: has_self_reference,
+            eof_tail,
+            contains_self_ref_opt: has_self_ref,
         })
+    }
+
+    fn member_is_self_referential(
+        &self,
+        decl: &NamedDeclaration,
+        tab: &ValidatedSymbolTable,
+    ) -> bool {
+        match &decl.kind {
+            DeclarationKind::Optional(xdr_type) => xdr_type.self_referential_optional(tab),
+            DeclarationKind::Scalar(xdr_type) => xdr_type.self_referential_optional(tab),
+            _ => false,
+        }
     }
 
     /// Determine if a struct has a "self-referential optional":
@@ -666,6 +716,8 @@ mod tests {
                     deps: vec!["b".to_string()],
                 },
                 self_referential_optional: false,
+                contains_self_ref_opt: false,
+                eof_tail: false,
             }
         );
 
@@ -714,6 +766,8 @@ mod tests {
                     deps: vec!["bar".to_string()],
                 },
                 self_referential_optional: false,
+                contains_self_ref_opt: false,
+                eof_tail: false,
             }
         );
     }

--- a/xdr_lib/src/lib.rs
+++ b/xdr_lib/src/lib.rs
@@ -143,6 +143,9 @@ pub struct LinkedListIter<'a, T> {
 
     pub _marker: PhantomData<T>,
     err: bool,
+
+    width_cache: Option<&'a std::cell::OnceCell<usize>>,
+    eof_tail: bool,
 }
 
 macro_rules! impl_reader_for_numeric {
@@ -199,7 +202,12 @@ where
 }
 
 impl<'a, T> LinkedListIter<'a, T> {
-    pub fn new(buf: &'a [u8], item_width: Option<usize>) -> Self {
+    pub fn new(
+        buf: &'a [u8],
+        item_width: Option<usize>,
+        width_cache: Option<&'a std::cell::OnceCell<usize>>,
+        eof_tail: bool,
+    ) -> Self {
         Self {
             buf,
             item_width,
@@ -207,6 +215,8 @@ impl<'a, T> LinkedListIter<'a, T> {
             i: 0,
             _marker: PhantomData,
             err: false,
+            width_cache,
+            eof_tail,
         }
     }
 
@@ -236,6 +246,15 @@ where
         self.off += 4;
 
         if has_val == 0 {
+            if let Some(cell) = self.width_cache {
+                let _ = cell.get_or_init(|| self.off);
+            }
+
+            if self.eof_tail && self.off + 4 >= self.buf.len() {
+                self.err = true;
+                return Some(Err(DeserializeError));
+            }
+
             return None;
         }
 


### PR DESCRIPTION
Allows for structures like
```
struct Dirlist {
    Entry* entry_list;
    bool eof;
}
```

Custom checks are added such that `bool eof;` is the only thing allowed to trail behind self-recursive optionals. Furthermore, I rewrote the LinkedList width caching logic. Excited to see how much of a performance regression this optimization will bring.